### PR TITLE
Uncommented test methods in product use cases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM openjdk:17
-COPY ./build/libs/techchallenge3-1.0-SNAPSHOT.jar /app.jar
+COPY ./build/libs/tech-challenge-pedido-backend-1.0-SNAPSHOT.jar /app.jar
 ENTRYPOINT ["java", "-jar", "/app.jar"]


### PR DESCRIPTION
This commit uncomments the previously commented-out test methods in the product use cases 'FindProductImplTest', 'FindByProductCategoryImplTest', and 'CreateProductImplTest'. These tests are now enabled and will be run during the testing phase.