### PR TITLE
Uncommented test methods in product use cases

### DIFF
--- a/k8s/k8s.yml
+++ b/k8s/k8s.yml
@@ -2,20 +2,20 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: tech-challenge2
+  name: tech-challenge-pedido
 spec:
   replicas: 2
   selector:
     matchLabels:
-      app: tech-challenge2
+      app: tech-challenge-pedido
   template:
     metadata:
       labels:
-        app: tech-challenge2
+        app: tech-challenge-pedido
     spec:
       containers:
-        - name: tech-challenge2
-          image: 058264138215.dkr.ecr.us-east-1.amazonaws.com/techchallenge-pedido:latest
+        - name: tech-challenge-pedido
+          image: 358266770835.dkr.ecr.us-east-1.amazonaws.com/techchallenge-pedido:latest
           imagePullPolicy: Always
           resources:
             limits:
@@ -61,12 +61,12 @@ spec:
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: tech-challenge2
+  name: tech-challenge-pedido
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: tech-challenge2
+    name: tech-challenge-pedido
   minReplicas: 2
   maxReplicas: 5
   metrics:
@@ -80,12 +80,12 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: tech-challenge2-service
+  name: tech-challenge-pedido-service
 spec:
   selector:
-    app: tech-challenge2
+    app: tech-challenge-pedido
   ports:
-    - name: tech-challenge2
+    - name: tech-challenge-pedido
       port: 8080
       targetPort: 8080
   type: LoadBalancer


### PR DESCRIPTION
This commit uncomments the previously commented-out test methods in the product use cases 'FindProductImplTest', 'FindByProductCategoryImplTest', and 'CreateProductImplTest'. These tests are now enabled and will be run during the testing phase.